### PR TITLE
:hammer::green_heart: Refactor release process by creating a new scri…

### DIFF
--- a/.github/workflows/2.create-release.yml
+++ b/.github/workflows/2.create-release.yml
@@ -23,4 +23,4 @@ jobs:
       - name: Create release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release create v$(./scripts/get-version.sh) --generate-notes
+        run: ./scripts/release.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # File created using '.gitignore Generator' for Visual Studio Code: https://bit.ly/vscode-gig
-# Created by https://www.toptal.com/developers/gitignore/api/zsh,windows,visualstudiocode,vim,sublimetext,python,powershell,macos,linux,jupyternotebooks,jetbrains+all,xcode
-# Edit at https://www.toptal.com/developers/gitignore?templates=zsh,windows,visualstudiocode,vim,sublimetext,python,powershell,macos,linux,jupyternotebooks,jetbrains+all,xcode
+# Created by https://www.toptal.com/developers/gitignore/api/zsh,xcode,windows,visualstudiocode,vim,sublimetext,python,powershell,macos,linux,jupyternotebooks,jetbrains+all,obsidian
+# Edit at https://www.toptal.com/developers/gitignore?templates=zsh,xcode,windows,visualstudiocode,vim,sublimetext,python,powershell,macos,linux,jupyternotebooks,jetbrains+all,obsidian
 
 ### JetBrains+all ###
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
@@ -126,8 +126,7 @@ ipython_config.py
 .LSOverride
 
 # Icon must end with two \r
-Icon
-
+Icon
 
 # Thumbnails
 ._*
@@ -151,6 +150,10 @@ Temporary Items
 ### macOS Patch ###
 # iCloud generated files
 *.icloud
+
+### Obsidian ###
+# config dir
+.obsidian/
 
 ### PowerShell ###
 # Exclude packaged modules
@@ -478,10 +481,9 @@ zsdoc/data
 /tests/_output/*
 !/tests/_output/.gitkeep
 
-# End of https://www.toptal.com/developers/gitignore/api/zsh,windows,visualstudiocode,vim,sublimetext,python,powershell,macos,linux,jupyternotebooks,jetbrains+all,xcode
+# End of https://www.toptal.com/developers/gitignore/api/zsh,xcode,windows,visualstudiocode,vim,sublimetext,python,powershell,macos,linux,jupyternotebooks,jetbrains+all,obsidian
 
 # Custom rules (everything added below won't be overriden by 'Generate .gitignore File' if you use 'Update' option)
-
 
 # Directories:
 log/

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -euo pipefail
+
+## --- Base --- ##
+# Getting path of this script file:
+_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+_PROJECT_DIR="$(cd "${_SCRIPT_DIR}/.." >/dev/null 2>&1 && pwd)"
+cd "${_PROJECT_DIR}" || exit 2
+
+# Loading .env file:
+if [ -f ".env" ]; then
+	# shellcheck disable=SC1091
+	source .env
+fi
+
+if [ -z "$(which git)" ]; then
+	echo "[ERROR]: 'git' not found or not installed!"
+	exit 1
+fi
+
+if [ -z "$(which gh)" ]; then
+	echo "[ERROR]: 'gh' not found or not installed!"
+	exit 1
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+	echo "[ERROR]: You need to login: 'gh auth login'"
+	exit 1
+fi
+## --- Base --- ##
+
+
+## --- Main --- ##
+main()
+{
+	_cur_version="$(./scripts/get-version.sh)"
+	echo "[INFO]: Creating release for version: 'v${_cur_version}'..."
+	gh release create "v${_cur_version}" --generate-notes
+	echo "[OK]: Done."
+}
+
+main "${@:-}"
+## --- Main --- ##


### PR DESCRIPTION
This pull request updates the release creation process by replacing the direct `gh release create` command with a new script, `scripts/release.sh`. The script adds error handling, environment file loading, and validation steps to ensure a more robust and consistent release workflow.

### Release process improvement:

* [`.github/workflows/2.create-release.yml`](diffhunk://#diff-a958c247983d0d2257006ca17bf6f1e0e5f6e9d748752d7099259ca7fe824405L26-R26): Updated the release creation step to use the new `scripts/release.sh` script instead of directly running the `gh release create` command.
* [`scripts/release.sh`](diffhunk://#diff-1bba00e5aca52286a667c09eff92ba2ca8e3ca77e0d31b0599cc829ab0173389R1-R43): Added a new script to handle release creation. The script includes environment variable loading, validation for required tools (`git` and `gh`), authentication checks, and execution of the release creation command with notes generation.